### PR TITLE
Updated package.xml version from v0.0.6 to v0.0.10

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>meshrender</name>
-  <version>0.0.6</version>
+  <version>0.0.10</version>
   <description>The meshrender package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 


### PR DESCRIPTION
Errors     << meshrender:cmake /panda_autograsp_ws/logs/meshrender/build.cmake.000.log
*** Arguments ['setup_requires'] to setup() not supported in catkin devel space in setup.py of meshrender
CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkin_python_setup.cmake:79 (message):
  catkin_python_setup() version in setup.py (0.0.10) differs from version in
  package.xml (0.0.6)
Call Stack (most recent call first):
  CMakeLists.txt:16 (catkin_python_setup)